### PR TITLE
Explore GitHub workflow runtime environment

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: TEMPORARY Exploratory Log Emissions
+        run: env
       - name: Lint and Test
         run: |
           npm ci


### PR DESCRIPTION
Introduces an `env` command into the check workflow. This is being used to explore the environment variables that GitHub's runtime environment makes available to us as it's not always obvious from their documentation what _exactly_ they do. I'm writing code to parse them so want to understand their behaviours.

I will add two comments to this pull request:

1. `env` when the workflow runs in the context of this pull request: [here](https://github.com/ably/repository-audit/pull/14#issuecomment-931529265)
2. `env` when the workflow runs on the `main` branch: _to come_