### PR TITLE
Make repository names clickable in check reports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,8 @@ async function audit() {
       // Only create a section if it wasn't a PASS.
       const result = results[code];
       if (!result.isPass) {
-        md.h(3, `\`${name}\` check ${code}`);
+        const interactiveName = `[${name}](${github.repositoryURL(orgName, name)})`;
+        md.h(3, `${interactiveName} check ${code}`);
         md.line(`${result.emoji} ${result.description}`);
       }
     });


### PR DESCRIPTION
This is a small incremental improvement I identified while playing around this afternoon.

Once you are at the part of the report where you're viewing the failed checks for a particular repository then it is very likely you'll want to navigate to that repository to fix them up.