### PR TITLE
`npm audit fix` for 5 high severity vulnerabilities in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3880,9 +3880,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }


### PR DESCRIPTION
It may be of interest to reviewers for me to note that there is nothing to preview in terms of generated report output from this change, and that's likely a good sign.

If there was something to preview then a new branch would have been created for this pull request in one of the downstream repositories ([public](https://github.com/ably/repository-audit-report/branches/all) or [internal](https://github.com/ably/repository-audit-report-internal/branches/all)). However, there is no `preview/pulls/54` branch in either. 👍 

This is because the rehearse workflow had nothing to change from the current state of the default (`main`) branches in those repositories - see [here (public)](https://github.com/ably/repository-audit/runs/5317837434?check_suite_focus=true#step:5:32):

```
===> 11:11:59 No changes to publish
```

and [here (internal)](https://github.com/ably/repository-audit/runs/5317837434?check_suite_focus=true#step:4:33):

```
===> 11:11:58 No changes to publish
```

Disregarding the changes in this PR, the normal reason for there to be no changes to publish is because none of the repositories being monitored are reporting a change of state. And I assume that was the case at the time the checks were run for this PR.

Considering the changes in this PR, if there were changes to publish then we would have to be considering whether those changes were caused by something broken in this change or whether they were simply coincidental changes occurring in the monitored repositories.